### PR TITLE
Fire event when copy is completed

### DIFF
--- a/scp-copy/README.md
+++ b/scp-copy/README.md
@@ -2,6 +2,9 @@
 
 An automated way of copying snapshots to remote location.
 
+When copy is complete, the event scp_copy_complete is fired. Data in the event is
+	result = return code of the SCP operation. 0 is success, anything else indicates an error.
+
 ![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg

--- a/scp-copy/config.json
+++ b/scp-copy/config.json
@@ -1,5 +1,5 @@
 {
-  "name": "SCP Copy-jf",
+  "name": "SCP Copy",
   "version": "1.1.0",
   "slug": "scp_copy",
   "description": "Copies snapshots to a remote location via SCP",

--- a/scp-copy/config.json
+++ b/scp-copy/config.json
@@ -1,6 +1,6 @@
 {
-  "name": "SCP Copy",
-  "version": "1.0.3",
+  "name": "SCP Copy-jf",
+  "version": "1.1.0",
   "slug": "scp_copy",
   "description": "Copies snapshots to a remote location via SCP",
   "arch": ["armhf", "armv7", "amd64", "i386"],
@@ -18,5 +18,6 @@
     "remote_host": "str",
     "remote_user": "str",
     "remote_path": "str"
-  }
+  },
+  "homeassistant_api": true
 }

--- a/scp-copy/data/run.sh
+++ b/scp-copy/data/run.sh
@@ -1,14 +1,23 @@
 #!/usr/bin/with-contenv bashio
 
-bashio::log.info "Starting SCP copy..."
+bashio::log.info "Starting SCP copy"
 
 files=`find /backup -name *.tar -maxdepth 1 -mtime -1`
 
-bashio::log.info $files 
+bashio::log.info "files to be copied:" $files 
 
-exec /usr/bin/scp -i "$(bashio::config 'private_key')" -o \
+/usr/bin/scp -i "$(bashio::config 'private_key')" -o \
 	StrictHostKeyChecking=no \
 	$files \
 	$(bashio::config 'remote_user')@$(bashio::config 'remote_host'):"$(bashio::config 'remote_path')"
+RESULT=$?
 
-bashio::log.info "SCP copy complete..."
+bashio::log.info "SCP completed to $(bashio::config 'remote_host')"
+
+bashio::log.info "Post scp_copy_complete event"
+bashio::log.info `curl --no-progress-meter -X POST -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" -H "Content-Type: application/json" --data "{\"result\":\"${RESULT}\"}" "http://supervisor/core/api/events/scp_copy_complete" 2>&1`
+
+bashio::log.info "Posted event"
+
+
+bashio::log.info "Done  `date`"

--- a/scp-copy/data/run.sh
+++ b/scp-copy/data/run.sh
@@ -20,4 +20,4 @@ bashio::log.info `curl --no-progress-meter -X POST -H "Authorization: Bearer ${S
 bashio::log.info "Posted event"
 
 
-bashio::log.info "Done  `date`"
+bashio::log.info "Done"


### PR DESCRIPTION
I made a change to the scp-copy addon to fire an event when the copy is completed. I use this to verify that backups have been run and to alert me if they do not for whatever reason (and then can investigate and fix the issue)